### PR TITLE
Allow rocks to be placed on all terracotta blocks

### DIFF
--- a/src/main/resources/data/earlygame/tags/blocks/rock_placeable_on.json
+++ b/src/main/resources/data/earlygame/tags/blocks/rock_placeable_on.json
@@ -7,7 +7,7 @@
     "minecraft:gravel",
     "minecraft:sand",
     "minecraft:red_sand",
-    "minecraft:terracotta",
+    "#minecraft:terracotta",
     "minecraft:stone",
     "minecraft:andesite",
     "minecraft:diorite",


### PR DESCRIPTION
Utilizes the `minecraft:terracotta` *tag* (not *block*) to allow rocks to be placed on all terracotta blocks.